### PR TITLE
fix: ensure Firebase SDK loads for games

### DIFF
--- a/admin-standalone.html
+++ b/admin-standalone.html
@@ -51,7 +51,7 @@
       <textarea id="packJson" rows="3" placeholder='[{"cz":"pes","en":"dog"}]'></textarea>
     </div>
     <button id="btnSavePack" class="row">Uložit balíček</button>
-    <table><thead><tr><th>Název</th><th>Počet</th><th>ID</th></tr></thead><tbody id="packs"></tbody></table>
+    <table><thead><tr><th>Název</th><th>Počet</th></tr></thead><tbody id="packs"></tbody></table>
   </div>
 </div>
 
@@ -61,7 +61,7 @@
     apiKey: "AIzaSyDxLM9oc3-zmhJRGYTDa04Wkjk7qS3gtl8",
     authDomain: "lada-anglictina-app.firebaseapp.com",
     projectId: "lada-anglictina-app",
-    storageBucket: "lada-anglictina-app.firebasestorage.app",
+    storageBucket: "lada-anglictina-app.appspot.com",
     messagingSenderId: "281293994339",
     appId: "1:281293994339:web:e4f798ff03c9a867b97b56",
     measurementId: "G-64SV0CKN0P"
@@ -142,7 +142,7 @@
       snap.forEach(d=>{
         const p = d.data();
         const tr = document.createElement("tr");
-        tr.innerHTML = `<td>${p.name}</td><td>${(p.pairs||[]).length}</td><td>${d.id}</td>`;
+        tr.innerHTML = `<td>${p.name}</td><td>${(p.pairs||[]).length}</td>`;
         packsBody.appendChild(tr);
       });
     }

--- a/admin.js
+++ b/admin.js
@@ -52,21 +52,28 @@ const state = {
 
 /* ========= ACTIVITY MAP =========
    Klíče (id) musí odpovídat složkám v /games/<id>/index.html
-   Přidávám aliasy pro starší názvy ("matching" -> "word-match", "typing" -> "write-word")
+   KEY_ALIASES mapuje starší názvy ("matching", "typing") na kanonické id.
 */
 const ACTIVITIES = {
   'flashcards':     { id: 'flashcards',     name: 'Kartičky',       path: 'games/flashcards/index.html' },
   'missing-letters':{ id: 'missing-letters',name: 'Doplň písmena',  path: 'games/missing-letters/index.html' },
   'word-match':     { id: 'word-match',     name: 'Spoj dvojice',   path: 'games/word-match/index.html' },
   'write-word':     { id: 'write-word',     name: 'Psaní',          path: 'games/write-word/index.html' },
-
-  // aliasy kvůli minulým hodnotám ve selectu
-  'matching':       { id: 'word-match',     name: 'Spoj dvojice',   path: 'games/word-match/index.html' },
-  'typing':         { id: 'write-word',     name: 'Psaní',          path: 'games/write-word/index.html' },
 };
 
+// aliasy starších názvů → kanonické id
+const KEY_ALIASES = {
+  'matching': 'word-match',
+  'typing':   'write-word',
+};
+
+function normalizeActivityKey(keyRaw) {
+  const k = (keyRaw || '').trim().toLowerCase();
+  return KEY_ALIASES[k] || k;
+}
+
 function activityFromKey(keyRaw) {
-  const key = (keyRaw || '').trim();
+  const key = normalizeActivityKey(keyRaw);
   return ACTIVITIES[key] || null;
 }
 
@@ -163,7 +170,6 @@ function renderStudentsTable() {
       <td>${s.name || ''}</td>
       <td>${mono(s.code || '')}</td>
       <td>${mono(s.pin || '')}</td>
-      <td class="mono small">${s.id}</td>
       <td class="small">
         <span class="muted">
           [<a href="#" data-act="edit" data-id="${s.id}">upravit</a> |
@@ -180,7 +186,7 @@ function renderStudentsTable() {
 function refreshStudentSelect() {
   if (!el.studentSelect) return;
   const arr = [...state.students.values()].sort((a,b)=> (a.name||'').localeCompare(b.name||''));
-  el.studentSelect.innerHTML = arr.map(s => `<option value="${s.id}">${s.name || s.id}</option>`).join('');
+  el.studentSelect.innerHTML = arr.map(s => `<option value="${s.id}">${s.name || '(bez jména)'}</option>`).join('');
 }
 
 function startStudentsListener() {
@@ -249,7 +255,6 @@ function renderPacksTable() {
     tr.innerHTML = `
       <td>${p.name || ''}</td>
       <td>${count}</td>
-      <td class="mono small">${p.id}</td>
       <td class="small">
         <span class="muted">
           [<a href="#" data-act="edit" data-id="${p.id}">upravit</a> |
@@ -389,16 +394,37 @@ el.savePackBtn?.addEventListener('click', async () => {
 
 function ensureActivitySelectOptions() {
   if (!el.activitySelect) return;
-  // Pokud už máš v HTML ručně, jen doplníme chybějící/normalizujeme
-  const current = new Set($$('#activitySelect option').map(o => o.value));
-  // vždy chceme preferovat klíče z ACTIVITIES (včetně aliasů)
-  for (const key of Object.keys(ACTIVITIES)) {
-    if (!current.has(key)) {
-      const opt = document.createElement('option');
-      opt.value = key;
-      opt.textContent = ACTIVITIES[key].name;
-      el.activitySelect.appendChild(opt);
+
+  // Zajistíme, že select obsahuje každou aktivitu jen jednou, vždy s kanonickým id
+  const seen = new Set();
+
+  // Normalizujeme existující <option> a odstraníme duplicitní aliasy
+  $$('#activitySelect option').forEach(opt => {
+    const act = activityFromKey(opt.value);
+    if (!act) return; // neznámá hodnota
+
+    // pokud už jsme kanonické id viděli, odstraníme aliasovou položku
+    if (seen.has(act.id)) {
+      opt.remove();
+      return;
     }
+
+    // přepíšeme hodnotu i text na kanonické údaje
+    opt.value = act.id;
+    opt.textContent = act.name;
+    seen.add(act.id);
+  });
+
+  // Doplníme chybějící aktivity (aliasy ignorujeme)
+  for (const key of Object.keys(ACTIVITIES)) {
+    const act = ACTIVITIES[key];
+    if (seen.has(act.id)) continue;
+
+    const opt = document.createElement('option');
+    opt.value = act.id;
+    opt.textContent = act.name;
+    el.activitySelect.appendChild(opt);
+    seen.add(act.id);
   }
 }
 
@@ -416,10 +442,9 @@ function renderAssignmentsTable() {
   for (const asg of items) {
     const tr = document.createElement('tr');
     tr.innerHTML = `
-      <td>${asg.studentName || asg.studentId}</td>
-      <td>${asg.packName || asg.packId}</td>
-      <td>${asg.activityName || asg.activityId || '-'}</td>
-      <td class="mono small">${asg.id}</td>
+      <td>${asg.studentName || ''}</td>
+      <td>${asg.packName || ''}</td>
+      <td>${asg.activityName || '-'}</td>
       <td class="small">
         <span class="muted">
           [<a href="#" data-act="edit" data-id="${asg.id}">upravit</a> |

--- a/firebase.js
+++ b/firebase.js
@@ -11,7 +11,7 @@
       apiKey: "AIzaSyDxLM9oc3-zmhJRGYTDa04Wkjk7qS3gtl8",
       authDomain:"lada-anglictina-app.firebaseapp.com",
       projectId: "lada-anglictina-app",
-      storageBucket:"lada-anglictina-app.firebasestorage.app",
+      storageBucket:"lada-anglictina-app.appspot.com",
       messagingSenderId: "281293994339",
       appId: "1:281293994339:web:e4f798ff03c9a867b97b56",
       measurementId: "G-64SV0CKN0P"

--- a/games/flashcards/flashcards.html
+++ b/games/flashcards/flashcards.html
@@ -10,15 +10,14 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-  <!-- Firebase + SDK (očekává se, že /firebase.js sedí v kořeni webu) -->
-  <script defer src="/firebase.js"></script>
-  <script defer src="../sdk.js"></script>
+    <!-- Firebase + SDK (očekává se, že firebase.js sedí v kořeni webu) -->
+    <script defer src="../firebase.js"></script>
+    <script defer src="../sdk.js"></script>
 </head>
 <body>
 <div class="container">
   <div class="card">
-    <h1>Flashcards</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+      <h1>Flashcards</h1>
     
 <div id="panel" class="row">
   <div id="q" class="badge" style="font-size:28px"></div>
@@ -39,25 +38,30 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
-  let i = 0, right = 0;
-  const el = (id)=>document.getElementById(id);
-  function show() {
-    if (!pairs.length) { el("q").textContent = "Žádná data"; return; }
-    const cur = pairs[i];
-    el("q").textContent = cur.question;
-    el("a").textContent = "";
+  try {
+    const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
+    let i = 0, right = 0;
+    const el = (id)=>document.getElementById(id);
+    function show() {
+      if (!pairs.length) { el("q").textContent = "Žádná data"; return; }
+      const cur = pairs[i];
+      el("q").textContent = cur.question;
+      el("a").textContent = "";
+    }
+    el("show").onclick = ()=> { el("a").textContent = pairs[i].answer; };
+    el("next").onclick = ()=> { i = (i+1) % pairs.length; show(); };
+    el("ok").onclick = ()=> { right++; i = (i+1) % pairs.length; show(); };
+    el("no").onclick = ()=> { i = (i+1) % pairs.length; show(); };
+    el("finish").onclick = async ()=>{
+      await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
+      alert(`Uloženo: ${right}/${pairs.length}`);
+      location.href = "../student.html";
+    };
+    show();
+  } catch (err) {
+    console.error('Chyba při initu hry:', err);
+    alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-  el("show").onclick = ()=> { el("a").textContent = pairs[i].answer; };
-  el("next").onclick = ()=> { i = (i+1) % pairs.length; show(); };
-  el("ok").onclick = ()=> { right++; i = (i+1) % pairs.length; show(); };
-  el("no").onclick = ()=> { i = (i+1) % pairs.length; show(); };
-  el("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
-    alert(`Uloženo: ${right}/${pairs.length}`);
-    location.href = "/student.html";
-  };
-  show();
 })();
 </script>
 </body>

--- a/games/flashcards/flashcards.html
+++ b/games/flashcards/flashcards.html
@@ -5,9 +5,14 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Flashcards</title>
   <link rel="stylesheet" href="style.css" />
+
+  <!-- Firebase (compat) -->
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <!-- Firebase + SDK (očekává se, že /firebase.js sedí v kořeni webu) -->
-  <script src="/firebase.js"></script>
-  <script src="../sdk.js"></script>
+  <script defer src="/firebase.js"></script>
+  <script defer src="../sdk.js"></script>
 </head>
 <body>
 <div class="container">

--- a/games/flashcards/flashcards.html
+++ b/games/flashcards/flashcards.html
@@ -11,7 +11,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
     <!-- Firebase + SDK (očekává se, že firebase.js sedí v kořeni webu) -->
-    <script defer src="../firebase.js"></script>
+    <script defer src="../../firebase.js"></script>
     <script defer src="../sdk.js"></script>
 </head>
 <body>

--- a/games/flashcards/flashcards.html
+++ b/games/flashcards/flashcards.html
@@ -37,7 +37,7 @@
   </div>
 </div>
 <script>
-(async () => {
+window.addEventListener('DOMContentLoaded', async () => {
   try {
     const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
     let i = 0, right = 0;
@@ -62,7 +62,7 @@
     console.error('Chyba při initu hry:', err);
     alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-})();
+});
 </script>
 </body>
 </html>

--- a/games/flashcards/index.html
+++ b/games/flashcards/index.html
@@ -38,7 +38,7 @@
   </div>
 </div>
 <script>
-(async () => {
+window.addEventListener('DOMContentLoaded', async () => {
   try {
     const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
     let i = 0, right = 0;
@@ -63,7 +63,7 @@
     console.error('Chyba při initu hry:', err);
     alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-})();
+});
 </script>
 </body>
 </html>

--- a/games/flashcards/index.html
+++ b/games/flashcards/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-  <script defer src="../firebase.js"></script>         <!-- globální init Firebase -->
+  <script defer src="../../firebase.js"></script>         <!-- globální init Firebase -->
   <script defer src="../sdk.js"></script>              <!-- nový SDK -->
 
 </head>

--- a/games/flashcards/index.html
+++ b/games/flashcards/index.html
@@ -5,30 +5,20 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Flashcards</title>
   <link rel="stylesheet" href="style.css" />
-  <link rel="stylesheet" href="/styles.css">   <!-- společné styly -->
+  <link rel="stylesheet" href="../styles.css">   <!-- společné styly -->
 
   <!-- Firebase (compat) -->
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-  <script defer src="/firebase.js"></script>         <!-- globální init Firebase -->
-  <script defer src="/games/sdk.js"></script>        <!-- nový SDK -->
-
-  <script>
-  const params = new URLSearchParams(location.search);
-  const packId = params.get('pack');
-  const uid = params.get('uid'); // volitelné
-  if (!packId) {
-    alert('Chybí parametr pack.');
-  }
-</script>
+  <script defer src="../firebase.js"></script>         <!-- globální init Firebase -->
+  <script defer src="../sdk.js"></script>              <!-- nový SDK -->
 
 </head>
 <body>
 <div class="container">
   <div class="card">
     <h1>Flashcards</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
     
 <div id="panel" class="row">
   <div id="q" class="badge" style="font-size:28px"></div>
@@ -49,25 +39,30 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
-  let i = 0, right = 0;
-  const el = (id)=>document.getElementById(id);
-  function show() {
-    if (!pairs.length) { el("q").textContent = "Žádná data"; return; }
-    const cur = pairs[i];
-    el("q").textContent = cur.question;
-    el("a").textContent = "";
+  try {
+    const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
+    let i = 0, right = 0;
+    const el = (id)=>document.getElementById(id);
+    function show() {
+      if (!pairs.length) { el("q").textContent = "Žádná data"; return; }
+      const cur = pairs[i];
+      el("q").textContent = cur.question;
+      el("a").textContent = "";
+    }
+    el("show").onclick = ()=> { el("a").textContent = pairs[i].answer; };
+    el("next").onclick = ()=> { i = (i+1) % pairs.length; show(); };
+    el("ok").onclick = ()=> { right++; i = (i+1) % pairs.length; show(); };
+    el("no").onclick = ()=> { i = (i+1) % pairs.length; show(); };
+    el("finish").onclick = async ()=>{
+      await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
+      alert(`Uloženo: ${right}/${pairs.length}`);
+      location.href = "../student.html";
+    };
+    show();
+  } catch (err) {
+    console.error('Chyba při initu hry:', err);
+    alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-  el("show").onclick = ()=> { el("a").textContent = pairs[i].answer; };
-  el("next").onclick = ()=> { i = (i+1) % pairs.length; show(); };
-  el("ok").onclick = ()=> { right++; i = (i+1) % pairs.length; show(); };
-  el("no").onclick = ()=> { i = (i+1) % pairs.length; show(); };
-  el("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
-    alert(`Uloženo: ${right}/${pairs.length}`);
-    location.href = "/student.html";
-  };
-  show();
 })();
 </script>
 </body>

--- a/games/flashcards/index.html
+++ b/games/flashcards/index.html
@@ -6,8 +6,13 @@
   <title>Flashcards</title>
   <link rel="stylesheet" href="style.css" />
   <link rel="stylesheet" href="/styles.css">   <!-- společné styly -->
-<script src="/firebase.js"></script>         <!-- globální init Firebase -->
-<script src="/games/sdk.js"></script>        <!-- nový SDK -->
+
+  <!-- Firebase (compat) -->
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script defer src="/firebase.js"></script>         <!-- globální init Firebase -->
+  <script defer src="/games/sdk.js"></script>        <!-- nový SDK -->
 
   <script>
   const params = new URLSearchParams(location.search);

--- a/games/missing-letters/index.html
+++ b/games/missing-letters/index.html
@@ -11,7 +11,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-    <script defer src="../firebase.js"></script>         <!-- globální init Firebase -->
+    <script defer src="../../firebase.js"></script>         <!-- globální init Firebase -->
     <script defer src="../sdk.js"></script>              <!-- nový SDK -->
 
 

--- a/games/missing-letters/index.html
+++ b/games/missing-letters/index.html
@@ -6,14 +6,13 @@
   <title>Doplň chybějící písmena</title>
 
  <link rel="stylesheet" href="/styles.css">   <!-- společné styly -->
-<script src="/firebase.js"></script>         <!-- globální init Firebase -->
-<script src="/games/sdk.js"></script>        <!-- nový SDK -->
-
 
   <!-- Firebase stejné verze -->
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script defer src="/firebase.js"></script>         <!-- globální init Firebase -->
+  <script defer src="/games/sdk.js"></script>        <!-- nový SDK -->
 
 
   <style>

--- a/games/missing-letters/index.html
+++ b/games/missing-letters/index.html
@@ -112,7 +112,7 @@ function buildLetterBank(answer, needCount){
 }
 
 /* ===== Hra ===== */
-(async () => {
+window.addEventListener('DOMContentLoaded', async () => {
   try {
     const { pairs, assignmentId, direction, limit } = await GameSDK.init({ activityKey: "missing-letters" });
 
@@ -244,7 +244,7 @@ function buildLetterBank(answer, needCount){
     console.error("Chyba při initu hry:", err);
     alert(err?.message || "Nepodařilo se načíst data pro hru.");
   }
-})();
+});
 </script>
 </body>
 </html>

--- a/games/missing-letters/index.html
+++ b/games/missing-letters/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Doplň chybějící písmena</title>
 
- <link rel="stylesheet" href="/styles.css">   <!-- společné styly -->
+ <link rel="stylesheet" href="../styles.css">   <!-- společné styly -->
 
   <!-- Firebase stejné verze -->
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-  <script defer src="/firebase.js"></script>         <!-- globální init Firebase -->
-  <script defer src="/games/sdk.js"></script>        <!-- nový SDK -->
+    <script defer src="../firebase.js"></script>         <!-- globální init Firebase -->
+    <script defer src="../sdk.js"></script>              <!-- nový SDK -->
 
 
   <style>
@@ -62,7 +62,7 @@
         <div class="ml-feedback" id="feedback"></div>
 
         <div class="ml-actions" style="margin-top:18px">
-          <a href="/student.html" class="btn btn--secondary">⬅️ Zpět na výběr her</a>
+            <a href="../student.html" class="btn btn--secondary">⬅️ Zpět na výběr her</a>
           <button id="finishBtn" type="button" class="btn">Ukončit a uložit</button>
         </div>
 
@@ -234,7 +234,7 @@ function buildLetterBank(answer, needCount){
         extra: { direction, limit, activity: "missing-letters" }
       });
       alert(`Uloženo: ${score}/${pairs.length}`);
-      location.href = "/student.html";
+        location.href = "../student.html";
     };
 
     // start

--- a/games/word-match/index.html
+++ b/games/word-match/index.html
@@ -10,7 +10,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-    <script defer src="../firebase.js"></script>         <!-- globální init Firebase -->
+    <script defer src="../../firebase.js"></script>         <!-- globální init Firebase -->
     <script defer src="../sdk.js"></script>              <!-- nový SDK -->
 
 </head>

--- a/games/word-match/index.html
+++ b/games/word-match/index.html
@@ -27,7 +27,7 @@
   </div>
 </div>
 <script>
-(async () => {
+window.addEventListener('DOMContentLoaded', async () => {
   try {
     const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
     const left = pairs.map(p=>({text:p.question, id: p.question}));
@@ -83,7 +83,7 @@
     console.error('Chyba při initu hry:', err);
     alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-})();
+});
 </script>
 </body>
 </html>

--- a/games/word-match/index.html
+++ b/games/word-match/index.html
@@ -5,8 +5,13 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Word Match (spoj dvojice)</title>
   <link rel="stylesheet" href="/styles.css">   <!-- společné styly -->
-  <script src="/firebase.js"></script>         <!-- globální init Firebase -->
-  <script src="/games/sdk.js"></script>        <!-- nový SDK -->
+
+  <!-- Firebase (compat) -->
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script defer src="/firebase.js"></script>         <!-- globální init Firebase -->
+  <script defer src="/games/sdk.js"></script>        <!-- nový SDK -->
 
   <script>
   const params = new URLSearchParams(location.search);

--- a/games/word-match/index.html
+++ b/games/word-match/index.html
@@ -4,30 +4,20 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Word Match (spoj dvojice)</title>
-  <link rel="stylesheet" href="/styles.css">   <!-- společné styly -->
+    <link rel="stylesheet" href="../styles.css">   <!-- společné styly -->
 
   <!-- Firebase (compat) -->
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-  <script defer src="/firebase.js"></script>         <!-- globální init Firebase -->
-  <script defer src="/games/sdk.js"></script>        <!-- nový SDK -->
-
-  <script>
-  const params = new URLSearchParams(location.search);
-  const packId = params.get('pack');
-  const uid = params.get('uid'); // volitelné
-  if (!packId) {
-    alert('Chybí parametr pack.');
-  }
-</script>
+    <script defer src="../firebase.js"></script>         <!-- globální init Firebase -->
+    <script defer src="../sdk.js"></script>              <!-- nový SDK -->
 
 </head>
 <body>
 <div class="container">
   <div class="card">
-    <h1>Word Match (spoj dvojice)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+      <h1>Word Match (spoj dvojice)</h1>
     
 <div class="row grid-2" id="cols"></div>
 <div class="small">Klikni nejprve na výraz vlevo, pak na překlad vpravo.</div>
@@ -38,56 +28,61 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
-  const left = pairs.map(p=>({text:p.question, id: p.question}));
-  const right = pairs.map(p=>({text:p.answer, id: p.question}));
-  // shuffle
-  right.sort(()=>Math.random()-0.5);
-  const cols = document.getElementById("cols");
-  cols.innerHTML = `<div class="col" id="L"></div><div class="col" id="R"></div>`;
-  const L = document.getElementById("L");
-  const R = document.getElementById("R");
-  const prog = document.getElementById("progress");
-  let selectedLeft=null, selectedRight=null, solved=0;
-  function renderList(el, arr, side){
-    el.innerHTML = "";
-    arr.forEach(x=>{
-      const d = document.createElement("div");
-      d.className = "item";
-      d.textContent = x.text;
-      d.dataset.id = x.id;
-      d.onclick = ()=>{
-        if (d.classList.contains("done")) return;
-        el.querySelectorAll(".item").forEach(n=>n.classList.remove("active"));
-        d.classList.add("active");
-        if (side==="L"){ selectedLeft = x; }
-        else { selectedRight = x; }
-        check();
-      };
-      el.appendChild(d);
-    });
-  }
-  function check(){
-    if (selectedLeft && selectedRight){
-      const ok = selectedLeft.id === selectedRight.id;
-      const mark = (el, id) => {
-        const n = el.querySelector(`.item[data-id="${id}"]`);
-        if (n){ n.classList.remove("active"); if (ok){ n.classList.add("done"); n.style.pointerEvents="none"; } }
-      };
-      mark(L, selectedLeft.id); mark(R, selectedRight.id);
-      if (ok) solved++;
-      selectedLeft=null; selectedRight=null;
-      prog.textContent = `Správně: ${solved}/${pairs.length}`;
+  try {
+    const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
+    const left = pairs.map(p=>({text:p.question, id: p.question}));
+    const right = pairs.map(p=>({text:p.answer, id: p.question}));
+    // shuffle
+    right.sort(()=>Math.random()-0.5);
+    const cols = document.getElementById("cols");
+    cols.innerHTML = `<div class="col" id="L"></div><div class="col" id="R"></div>`;
+    const L = document.getElementById("L");
+    const R = document.getElementById("R");
+    const prog = document.getElementById("progress");
+    let selectedLeft=null, selectedRight=null, solved=0;
+    function renderList(el, arr, side){
+      el.innerHTML = "";
+      arr.forEach(x=>{
+        const d = document.createElement("div");
+        d.className = "item";
+        d.textContent = x.text;
+        d.dataset.id = x.id;
+        d.onclick = ()=>{
+          if (d.classList.contains("done")) return;
+          el.querySelectorAll(".item").forEach(n=>n.classList.remove("active"));
+          d.classList.add("active");
+          if (side==="L"){ selectedLeft = x; }
+          else { selectedRight = x; }
+          check();
+        };
+        el.appendChild(d);
+      });
     }
+    function check(){
+      if (selectedLeft && selectedRight){
+        const ok = selectedLeft.id === selectedRight.id;
+        const mark = (el, id) => {
+          const n = el.querySelector(`.item[data-id="${id}"]`);
+          if (n){ n.classList.remove("active"); if (ok){ n.classList.add("done"); n.style.pointerEvents="none"; } }
+        };
+        mark(L, selectedLeft.id); mark(R, selectedRight.id);
+        if (ok) solved++;
+        selectedLeft=null; selectedRight=null;
+        prog.textContent = `Správně: ${solved}/${pairs.length}`;
+      }
+    }
+    renderList(L, left, "L");
+    renderList(R, right, "R");
+    document.getElementById("finish").onclick = async ()=>{
+      await GameSDK.reportResult({ assignmentId, score: solved, total: pairs.length, extra: {direction} });
+      alert(`Uloženo: ${solved}/${pairs.length}`);
+      location.href = "../student.html";
+    };
+    prog.textContent = `Správně: 0/${pairs.length}`;
+  } catch (err) {
+    console.error('Chyba při initu hry:', err);
+    alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-  renderList(L, left, "L");
-  renderList(R, right, "R");
-  document.getElementById("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: solved, total: pairs.length, extra: {direction} });
-    alert(`Uloženo: ${solved}/${pairs.length}`);
-    location.href = "/student.html";
-  };
-  prog.textContent = `Správně: 0/${pairs.length}`;
 })();
 </script>
 </body>

--- a/games/word-match/word-match.html
+++ b/games/word-match/word-match.html
@@ -27,7 +27,7 @@
   </div>
 </div>
 <script>
-(async () => {
+window.addEventListener('DOMContentLoaded', async () => {
   try {
     const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
     const left = pairs.map(p=>({text:p.question, id: p.question}));
@@ -83,7 +83,7 @@
     console.error('Chyba při initu hry:', err);
     alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-})();
+});
 </script>
 </body>
 </html>

--- a/games/word-match/word-match.html
+++ b/games/word-match/word-match.html
@@ -10,15 +10,14 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-  <!-- Firebase + SDK (očekává se, že /firebase.js sedí v kořeni webu) -->
-  <script defer src="/firebase.js"></script>
-  <script defer src="../sdk.js"></script>
+    <!-- Firebase + SDK (očekává se, že firebase.js sedí v kořeni webu) -->
+    <script defer src="../firebase.js"></script>
+    <script defer src="../sdk.js"></script>
 </head>
 <body>
 <div class="container">
   <div class="card">
-    <h1>Word Match (spoj dvojice)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+      <h1>Word Match (spoj dvojice)</h1>
     
 <div class="row grid-2" id="cols"></div>
 <div class="small">Klikni nejprve na výraz vlevo, pak na překlad vpravo.</div>
@@ -29,56 +28,61 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
-  const left = pairs.map(p=>({text:p.question, id: p.question}));
-  const right = pairs.map(p=>({text:p.answer, id: p.question}));
-  // shuffle
-  right.sort(()=>Math.random()-0.5);
-  const cols = document.getElementById("cols");
-  cols.innerHTML = `<div class="col" id="L"></div><div class="col" id="R"></div>`;
-  const L = document.getElementById("L");
-  const R = document.getElementById("R");
-  const prog = document.getElementById("progress");
-  let selectedLeft=null, selectedRight=null, solved=0;
-  function renderList(el, arr, side){
-    el.innerHTML = "";
-    arr.forEach(x=>{
-      const d = document.createElement("div");
-      d.className = "item";
-      d.textContent = x.text;
-      d.dataset.id = x.id;
-      d.onclick = ()=>{
-        if (d.classList.contains("done")) return;
-        el.querySelectorAll(".item").forEach(n=>n.classList.remove("active"));
-        d.classList.add("active");
-        if (side==="L"){ selectedLeft = x; }
-        else { selectedRight = x; }
-        check();
-      };
-      el.appendChild(d);
-    });
-  }
-  function check(){
-    if (selectedLeft && selectedRight){
-      const ok = selectedLeft.id === selectedRight.id;
-      const mark = (el, id) => {
-        const n = el.querySelector(`.item[data-id="${id}"]`);
-        if (n){ n.classList.remove("active"); if (ok){ n.classList.add("done"); n.style.pointerEvents="none"; } }
-      };
-      mark(L, selectedLeft.id); mark(R, selectedRight.id);
-      if (ok) solved++;
-      selectedLeft=null; selectedRight=null;
-      prog.textContent = `Správně: ${solved}/${pairs.length}`;
+  try {
+    const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
+    const left = pairs.map(p=>({text:p.question, id: p.question}));
+    const right = pairs.map(p=>({text:p.answer, id: p.question}));
+    // shuffle
+    right.sort(()=>Math.random()-0.5);
+    const cols = document.getElementById("cols");
+    cols.innerHTML = `<div class="col" id="L"></div><div class="col" id="R"></div>`;
+    const L = document.getElementById("L");
+    const R = document.getElementById("R");
+    const prog = document.getElementById("progress");
+    let selectedLeft=null, selectedRight=null, solved=0;
+    function renderList(el, arr, side){
+      el.innerHTML = "";
+      arr.forEach(x=>{
+        const d = document.createElement("div");
+        d.className = "item";
+        d.textContent = x.text;
+        d.dataset.id = x.id;
+        d.onclick = ()=>{
+          if (d.classList.contains("done")) return;
+          el.querySelectorAll(".item").forEach(n=>n.classList.remove("active"));
+          d.classList.add("active");
+          if (side==="L"){ selectedLeft = x; }
+          else { selectedRight = x; }
+          check();
+        };
+        el.appendChild(d);
+      });
     }
+    function check(){
+      if (selectedLeft && selectedRight){
+        const ok = selectedLeft.id === selectedRight.id;
+        const mark = (el, id) => {
+          const n = el.querySelector(`.item[data-id="${id}"]`);
+          if (n){ n.classList.remove("active"); if (ok){ n.classList.add("done"); n.style.pointerEvents="none"; } }
+        };
+        mark(L, selectedLeft.id); mark(R, selectedRight.id);
+        if (ok) solved++;
+        selectedLeft=null; selectedRight=null;
+        prog.textContent = `Správně: ${solved}/${pairs.length}`;
+      }
+    }
+    renderList(L, left, "L");
+    renderList(R, right, "R");
+    document.getElementById("finish").onclick = async ()=>{
+      await GameSDK.reportResult({ assignmentId, score: solved, total: pairs.length, extra: {direction} });
+      alert(`Uloženo: ${solved}/${pairs.length}`);
+      location.href = "../student.html";
+    };
+    prog.textContent = `Správně: 0/${pairs.length}`;
+  } catch (err) {
+    console.error('Chyba při initu hry:', err);
+    alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-  renderList(L, left, "L");
-  renderList(R, right, "R");
-  document.getElementById("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: solved, total: pairs.length, extra: {direction} });
-    alert(`Uloženo: ${solved}/${pairs.length}`);
-    location.href = "/student.html";
-  };
-  prog.textContent = `Správně: 0/${pairs.length}`;
 })();
 </script>
 </body>

--- a/games/word-match/word-match.html
+++ b/games/word-match/word-match.html
@@ -11,7 +11,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
     <!-- Firebase + SDK (očekává se, že firebase.js sedí v kořeni webu) -->
-    <script defer src="../firebase.js"></script>
+    <script defer src="../../firebase.js"></script>
     <script defer src="../sdk.js"></script>
 </head>
 <body>

--- a/games/word-match/word-match.html
+++ b/games/word-match/word-match.html
@@ -5,9 +5,14 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Word Match (spoj dvojice)</title>
   <link rel="stylesheet" href="style.css" />
+
+  <!-- Firebase (compat) -->
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <!-- Firebase + SDK (očekává se, že /firebase.js sedí v kořeni webu) -->
-  <script src="/firebase.js"></script>
-  <script src="../sdk.js"></script>
+  <script defer src="/firebase.js"></script>
+  <script defer src="../sdk.js"></script>
 </head>
 <body>
 <div class="container">

--- a/games/write-word/index.html
+++ b/games/write-word/index.html
@@ -10,7 +10,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-    <script defer src="../firebase.js"></script>         <!-- globální init Firebase -->
+    <script defer src="../../firebase.js"></script>         <!-- globální init Firebase -->
     <script defer src="../sdk.js"></script>              <!-- nový SDK -->
 
 </head>

--- a/games/write-word/index.html
+++ b/games/write-word/index.html
@@ -4,30 +4,20 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Write Word (napiš překlad)</title>
-  <link rel="stylesheet" href="/styles.css">   <!-- společné styly -->
+    <link rel="stylesheet" href="../styles.css">   <!-- společné styly -->
 
   <!-- Firebase (compat) -->
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-  <script defer src="/firebase.js"></script>         <!-- globální init Firebase -->
-  <script defer src="/games/sdk.js"></script>        <!-- nový SDK -->
-
-  <script>
-  const params = new URLSearchParams(location.search);
-  const packId = params.get('pack');
-  const uid = params.get('uid'); // volitelné
-  if (!packId) {
-    alert('Chybí parametr pack.');
-  }
-</script>
+    <script defer src="../firebase.js"></script>         <!-- globální init Firebase -->
+    <script defer src="../sdk.js"></script>              <!-- nový SDK -->
 
 </head>
 <body>
 <div class="container">
   <div class="card">
-    <h1>Write Word (napiš překlad)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+      <h1>Write Word (napiš překlad)</h1>
     
 <div class="row">
   <div class="badge" id="q" style="font-size:24px"></div>
@@ -41,36 +31,41 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
-  let i=0, right=0;
-  const el = id=>document.getElementById(id);
-  function show(){
-    if (!pairs.length){ el("q").textContent="Žádná data"; return; }
-    el("q").textContent = pairs[i].question;
-    el("answer").value="";
-    el("answer").focus();
-    el("progress").textContent = `${i+1}/${pairs.length} • Správně: ${right}`;
-    el("feedback").textContent = "";
-  }
-  el("answer").addEventListener("keydown", (e)=>{
-    if (e.key==="Enter"){
-      const guess = el("answer").value.trim().toLowerCase();
-      const ok = guess === pairs[i].answer.trim().toLowerCase();
-      if (ok){ right++; el("feedback").textContent = "✅ Správně"; }
-      else { el("feedback").textContent = `❌ Správně: ${pairs[i].answer}`; }
-      i++; if (i>=pairs.length){ i=pairs.length-1; }
-      setTimeout(()=>{ if (i < pairs.length-0) { show(); } }, 400);
-      if (i>=pairs.length-0){
-        // hotovo
-      }
+  try {
+    const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
+    let i=0, right=0;
+    const el = id=>document.getElementById(id);
+    function show(){
+      if (!pairs.length){ el("q").textContent="Žádná data"; return; }
+      el("q").textContent = pairs[i].question;
+      el("answer").value="";
+      el("answer").focus();
+      el("progress").textContent = `${i+1}/${pairs.length} • Správně: ${right}`;
+      el("feedback").textContent = "";
     }
-  });
-  document.getElementById("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
-    alert(`Uloženo: ${right}/${pairs.length}`);
-    location.href = "/student.html";
-  };
-  show();
+    el("answer").addEventListener("keydown", (e)=>{
+      if (e.key==="Enter"){
+        const guess = el("answer").value.trim().toLowerCase();
+        const ok = guess === pairs[i].answer.trim().toLowerCase();
+        if (ok){ right++; el("feedback").textContent = "✅ Správně"; }
+        else { el("feedback").textContent = `❌ Správně: ${pairs[i].answer}`; }
+        i++; if (i>=pairs.length){ i=pairs.length-1; }
+        setTimeout(()=>{ if (i < pairs.length-0) { show(); } }, 400);
+        if (i>=pairs.length-0){
+          // hotovo
+        }
+      }
+    });
+    document.getElementById("finish").onclick = async ()=>{
+      await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
+      alert(`Uloženo: ${right}/${pairs.length}`);
+      location.href = "../student.html";
+    };
+    show();
+  } catch (err) {
+    console.error('Chyba při initu hry:', err);
+    alert(err?.message || 'Nepodařilo se načíst data pro hru.');
+  }
 })();
 </script>
 </body>

--- a/games/write-word/index.html
+++ b/games/write-word/index.html
@@ -30,7 +30,7 @@
   </div>
 </div>
 <script>
-(async () => {
+window.addEventListener('DOMContentLoaded', async () => {
   try {
     const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
     let i=0, right=0;
@@ -66,7 +66,7 @@
     console.error('Chyba při initu hry:', err);
     alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-})();
+});
 </script>
 </body>
 </html>

--- a/games/write-word/index.html
+++ b/games/write-word/index.html
@@ -5,8 +5,13 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Write Word (napiš překlad)</title>
   <link rel="stylesheet" href="/styles.css">   <!-- společné styly -->
-  <script src="/firebase.js"></script>         <!-- globální init Firebase -->
-  <script src="/games/sdk.js"></script>        <!-- nový SDK -->
+
+  <!-- Firebase (compat) -->
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+  <script defer src="/firebase.js"></script>         <!-- globální init Firebase -->
+  <script defer src="/games/sdk.js"></script>        <!-- nový SDK -->
 
   <script>
   const params = new URLSearchParams(location.search);

--- a/games/write-word/write-word.html
+++ b/games/write-word/write-word.html
@@ -5,9 +5,14 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Write Word (napiš překlad)</title>
   <link rel="stylesheet" href="style.css" />
+
+  <!-- Firebase (compat) -->
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
   <!-- Firebase + SDK (očekává se, že /firebase.js sedí v kořeni webu) -->
-  <script src="/firebase.js"></script>
-  <script src="../sdk.js"></script>
+  <script defer src="/firebase.js"></script>
+  <script defer src="../sdk.js"></script>
 </head>
 <body>
 <div class="container">

--- a/games/write-word/write-word.html
+++ b/games/write-word/write-word.html
@@ -10,15 +10,14 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
-  <!-- Firebase + SDK (očekává se, že /firebase.js sedí v kořeni webu) -->
-  <script defer src="/firebase.js"></script>
-  <script defer src="../sdk.js"></script>
+    <!-- Firebase + SDK (očekává se, že firebase.js sedí v kořeni webu) -->
+    <script defer src="../firebase.js"></script>
+    <script defer src="../sdk.js"></script>
 </head>
 <body>
 <div class="container">
   <div class="card">
-    <h1>Write Word (napiš překlad)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+      <h1>Write Word (napiš překlad)</h1>
     
 <div class="row">
   <div class="badge" id="q" style="font-size:24px"></div>
@@ -32,36 +31,41 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
-  let i=0, right=0;
-  const el = id=>document.getElementById(id);
-  function show(){
-    if (!pairs.length){ el("q").textContent="Žádná data"; return; }
-    el("q").textContent = pairs[i].question;
-    el("answer").value="";
-    el("answer").focus();
-    el("progress").textContent = `${i+1}/${pairs.length} • Správně: ${right}`;
-    el("feedback").textContent = "";
-  }
-  el("answer").addEventListener("keydown", (e)=>{
-    if (e.key==="Enter"){
-      const guess = el("answer").value.trim().toLowerCase();
-      const ok = guess === pairs[i].answer.trim().toLowerCase();
-      if (ok){ right++; el("feedback").textContent = "✅ Správně"; }
-      else { el("feedback").textContent = `❌ Správně: ${pairs[i].answer}`; }
-      i++; if (i>=pairs.length){ i=pairs.length-1; }
-      setTimeout(()=>{ if (i < pairs.length-0) { show(); } }, 400);
-      if (i>=pairs.length-0){
-        // hotovo
-      }
+  try {
+    const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
+    let i=0, right=0;
+    const el = id=>document.getElementById(id);
+    function show(){
+      if (!pairs.length){ el("q").textContent="Žádná data"; return; }
+      el("q").textContent = pairs[i].question;
+      el("answer").value="";
+      el("answer").focus();
+      el("progress").textContent = `${i+1}/${pairs.length} • Správně: ${right}`;
+      el("feedback").textContent = "";
     }
-  });
-  document.getElementById("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
-    alert(`Uloženo: ${right}/${pairs.length}`);
-    location.href = "/student.html";
-  };
-  show();
+    el("answer").addEventListener("keydown", (e)=>{
+      if (e.key==="Enter"){
+        const guess = el("answer").value.trim().toLowerCase();
+        const ok = guess === pairs[i].answer.trim().toLowerCase();
+        if (ok){ right++; el("feedback").textContent = "✅ Správně"; }
+        else { el("feedback").textContent = `❌ Správně: ${pairs[i].answer}`; }
+        i++; if (i>=pairs.length){ i=pairs.length-1; }
+        setTimeout(()=>{ if (i < pairs.length-0) { show(); } }, 400);
+        if (i>=pairs.length-0){
+          // hotovo
+        }
+      }
+    });
+    document.getElementById("finish").onclick = async ()=>{
+      await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
+      alert(`Uloženo: ${right}/${pairs.length}`);
+      location.href = "../student.html";
+    };
+    show();
+  } catch (err) {
+    console.error('Chyba při initu hry:', err);
+    alert(err?.message || 'Nepodařilo se načíst data pro hru.');
+  }
 })();
 </script>
 </body>

--- a/games/write-word/write-word.html
+++ b/games/write-word/write-word.html
@@ -11,7 +11,7 @@
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
   <script defer src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
     <!-- Firebase + SDK (očekává se, že firebase.js sedí v kořeni webu) -->
-    <script defer src="../firebase.js"></script>
+    <script defer src="../../firebase.js"></script>
     <script defer src="../sdk.js"></script>
 </head>
 <body>

--- a/games/write-word/write-word.html
+++ b/games/write-word/write-word.html
@@ -30,7 +30,7 @@
   </div>
 </div>
 <script>
-(async () => {
+window.addEventListener('DOMContentLoaded', async () => {
   try {
     const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
     let i=0, right=0;
@@ -66,7 +66,7 @@
     console.error('Chyba při initu hry:', err);
     alert(err?.message || 'Nepodařilo se načíst data pro hru.');
   }
-})();
+});
 </script>
 </body>
 </html>

--- a/student.html
+++ b/student.html
@@ -77,7 +77,7 @@
       apiKey: "AIzaSyDxLM9oc3-zmhJRGYTDa04Wkjk7qS3gtl8",
       authDomain:"lada-anglictina-app.firebaseapp.com",
       projectId: "lada-anglictina-app",
-      storageBucket:"lada-anglictina-app.firebasestorage.app",
+      storageBucket:"lada-anglictina-app.appspot.com",
       messagingSenderId: "281293994339",
       appId: "1:281293994339:web:e4f798ff03c9a867b97b56",
       measurementId: "G-64SV0CKN0P"

--- a/student.js
+++ b/student.js
@@ -117,9 +117,11 @@ function resolveActivityName(key, fallbackName) {
 }
 function resolveActivityPath(key) {
   const map = activitiesMap || DEFAULT_ACTIVITIES;
-  const raw = map[key]?.path;
+  let raw = map[key]?.path;
   if (!raw) return undefined;
-  return raw.startsWith('/') ? raw : `/games/${raw}`;
+  raw = raw.replace(/^\.?\/+, '');          // remove leading ./ or /
+  if (raw.startsWith('games/')) raw = raw.slice(6); // drop existing games/
+  return `/games/${raw}`;
 }
 
 // ====== Auth ======
@@ -241,7 +243,7 @@ function renderAssignments(items) {
 
     const tr = document.createElement('tr');
     tr.innerHTML = `
-      <td>${asg.packName || packId || '—'}</td>
+      <td>${asg.packName || '—'}</td>
       <td>${name}</td>
       <td>${status}</td>
       <td>
@@ -326,7 +328,7 @@ auth.onAuthStateChanged(async (u) => {
 
   if (u && savedId && !currentStudent) {
     currentStudent = { id: savedId, name: savedName || '' };
-    whoEl.textContent = `Přihlášen: ${currentStudent.name || savedId}`;
+    whoEl.textContent = `Přihlášen: ${currentStudent.name || currentStudent.code || ''}`;
     loginCard?.classList?.add('hidden');
     logoutBtn?.classList?.remove('hidden');
     studentArea?.classList?.remove('hidden');

--- a/student.js
+++ b/student.js
@@ -55,6 +55,7 @@ const NAME_ALIASES_CS = {
   'dopln-pismena': 'missing-letters',
   'dopln-chybejici-pismena': 'missing-letters',
   'parovani': 'word-match',
+  'spoj-dvojice': 'word-match',
   'psani': 'write-word',
   'psani-slova': 'write-word',
   'karticky': 'flashcards',
@@ -177,7 +178,7 @@ function logoutStudent() {
 // ====== Assignments ======
 function deriveActivityKeyFromAsg(asg) {
   // 1) machine pole
-  let key = normalizeActivityKey(asg.activity || asg.activityKey || asg.game || '');
+  let key = normalizeActivityKey(asg.activityId || asg.activity || asg.activityKey || asg.game || '');
   if (isKnownKey(key)) return key;
 
   // 2) podle názvu (case/diakritika ignor)


### PR DESCRIPTION
## Summary
- correct Firebase storage bucket URL
- defer-load Firebase SDK on all game pages before initializing GameSDK
- use relative paths for student game manifest to avoid 404s when hosted in a subdirectory
- normalize student game URLs to always resolve under `/games`
- deduplicate admin activity options by collapsing aliases to their canonical IDs
- map legacy 'typing' key to 'write-word' so both launch the same activity
- hide internal IDs in admin and student views so lists show only names and counts

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/lada-app/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b03287d5c8832aa45de7619f25cafd