### PR TITLE
Remove unused activityKey from game SDK initialization

### DIFF
--- a/games/flashcards/flashcards.html
+++ b/games/flashcards/flashcards.html
@@ -39,7 +39,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i = 0, right = 0;
   const el = (id)=>document.getElementById(id);
   function show() {

--- a/games/flashcards/index.html
+++ b/games/flashcards/index.html
@@ -49,7 +49,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i = 0, right = 0;
   const el = (id)=>document.getElementById(id);
   function show() {

--- a/games/missing-letters/index.html
+++ b/games/missing-letters/index.html
@@ -114,7 +114,7 @@ function buildLetterBank(answer, needCount){
 /* ===== Hra ===== */
 (async () => {
   try {
-    const { pairs, assignmentId, direction, limit } = await GameSDK.init({ activityKey: "missing-letters" });
+    const { pairs, assignmentId, direction } = await GameSDK.init();
 
     let round = 0;
     let score = 0;
@@ -231,7 +231,7 @@ function buildLetterBank(answer, needCount){
         assignmentId,
         score,
         total: pairs.length,
-        extra: { direction, limit, activity: "missing-letters" }
+        extra: { direction, activity: "missing-letters" }
       });
       alert(`Uloženo: ${score}/${pairs.length}`);
       location.href = "/student.html";

--- a/games/word-match/index.html
+++ b/games/word-match/index.html
@@ -38,7 +38,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   const left = pairs.map(p=>({text:p.question, id: p.question}));
   const right = pairs.map(p=>({text:p.answer, id: p.question}));
   // shuffle

--- a/games/word-match/word-match.html
+++ b/games/word-match/word-match.html
@@ -29,7 +29,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   const left = pairs.map(p=>({text:p.question, id: p.question}));
   const right = pairs.map(p=>({text:p.answer, id: p.question}));
   // shuffle

--- a/games/write-word/index.html
+++ b/games/write-word/index.html
@@ -41,7 +41,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i=0, right=0;
   const el = id=>document.getElementById(id);
   function show(){

--- a/games/write-word/write-word.html
+++ b/games/write-word/write-word.html
@@ -32,7 +32,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i=0, right=0;
   const el = id=>document.getElementById(id);
   function show(){


### PR DESCRIPTION
## Summary
- Initialize all games via `GameSDK.init()` without the unused `activityKey` argument
- Drop unused `limit` metadata in missing-letters result reporting

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3098da000832ab58b08ac11ab63a5