### PR TITLE
Remove unused activityKey from game SDK initialization

### DIFF
--- a/games/flashcards/flashcards.html
+++ b/games/flashcards/flashcards.html
@@ -18,7 +18,7 @@
 <div class="container">
   <div class="card">
     <h1>Flashcards</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div id="panel" class="row">
   <div id="q" class="badge" style="font-size:28px"></div>
@@ -39,7 +39,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i = 0, right = 0;
   const el = (id)=>document.getElementById(id);
   function show() {

--- a/games/flashcards/index.html
+++ b/games/flashcards/index.html
@@ -28,7 +28,7 @@
 <div class="container">
   <div class="card">
     <h1>Flashcards</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div id="panel" class="row">
   <div id="q" class="badge" style="font-size:28px"></div>
@@ -49,7 +49,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i = 0, right = 0;
   const el = (id)=>document.getElementById(id);
   function show() {

--- a/games/missing-letters/index.html
+++ b/games/missing-letters/index.html
@@ -114,7 +114,7 @@ function buildLetterBank(answer, needCount){
 /* ===== Hra ===== */
 (async () => {
   try {
-    const { pairs, assignmentId, direction, limit } = await GameSDK.init({ activityKey: "missing-letters" });
+    const { pairs, assignmentId, direction } = await GameSDK.init();
 
     let round = 0;
     let score = 0;
@@ -231,7 +231,7 @@ function buildLetterBank(answer, needCount){
         assignmentId,
         score,
         total: pairs.length,
-        extra: { direction, limit, activity: "missing-letters" }
+        extra: { direction, activity: "missing-letters" }
       });
       alert(`Uloženo: ${score}/${pairs.length}`);
       location.href = "/student.html";

--- a/games/word-match/index.html
+++ b/games/word-match/index.html
@@ -27,7 +27,7 @@
 <div class="container">
   <div class="card">
     <h1>Word Match (spoj dvojice)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div class="row grid-2" id="cols"></div>
 <div class="small">Klikni nejprve na výraz vlevo, pak na překlad vpravo.</div>
@@ -38,7 +38,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   const left = pairs.map(p=>({text:p.question, id: p.question}));
   const right = pairs.map(p=>({text:p.answer, id: p.question}));
   // shuffle

--- a/games/word-match/word-match.html
+++ b/games/word-match/word-match.html
@@ -18,7 +18,7 @@
 <div class="container">
   <div class="card">
     <h1>Word Match (spoj dvojice)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div class="row grid-2" id="cols"></div>
 <div class="small">Klikni nejprve na výraz vlevo, pak na překlad vpravo.</div>
@@ -29,7 +29,7 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   const left = pairs.map(p=>({text:p.question, id: p.question}));
   const right = pairs.map(p=>({text:p.answer, id: p.question}));
   // shuffle

--- a/games/write-word/index.html
+++ b/games/write-word/index.html
@@ -27,11 +27,14 @@
 <div class="container">
   <div class="card">
     <h1>Write Word (napiš překlad)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div class="row">
   <div class="badge" id="q" style="font-size:24px"></div>
-  <input id="answer" placeholder="Napiš překlad a Enter" />
+  <div class="row grid-2">
+    <button id="listen" title="Přehrát výslovnost">🔊</button>
+    <input id="answer" placeholder="Napiš překlad a Enter" />
+  </div>
   <div id="feedback" class="small"></div>
   <div class="badge" id="progress"></div>
   <button id="finish">Ukončit a uložit</button>
@@ -41,9 +44,15 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i=0, right=0;
   const el = id=>document.getElementById(id);
+  function speak(text){
+    if (!('speechSynthesis' in window)) return;
+    const u = new SpeechSynthesisUtterance(text);
+    speechSynthesis.cancel();
+    speechSynthesis.speak(u);
+  }
   function show(){
     if (!pairs.length){ el("q").textContent="Žádná data"; return; }
     el("q").textContent = pairs[i].question;
@@ -52,6 +61,7 @@
     el("progress").textContent = `${i+1}/${pairs.length} • Správně: ${right}`;
     el("feedback").textContent = "";
   }
+  el("listen").addEventListener("click", ()=>speak(pairs[i].answer));
   el("answer").addEventListener("keydown", (e)=>{
     if (e.key==="Enter"){
       const guess = el("answer").value.trim().toLowerCase();

--- a/games/write-word/write-word.html
+++ b/games/write-word/write-word.html
@@ -18,11 +18,14 @@
 <div class="container">
   <div class="card">
     <h1>Write Word (napiš překlad)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div class="row">
   <div class="badge" id="q" style="font-size:24px"></div>
-  <input id="answer" placeholder="Napiš překlad a Enter" />
+  <div class="row grid-2">
+    <button id="listen" title="Přehrát výslovnost">🔊</button>
+    <input id="answer" placeholder="Napiš překlad a Enter" />
+  </div>
   <div id="feedback" class="small"></div>
   <div class="badge" id="progress"></div>
   <button id="finish">Ukončit a uložit</button>
@@ -32,9 +35,15 @@
 </div>
 <script>
 (async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i=0, right=0;
   const el = id=>document.getElementById(id);
+  function speak(text){
+    if (!('speechSynthesis' in window)) return;
+    const u = new SpeechSynthesisUtterance(text);
+    speechSynthesis.cancel();
+    speechSynthesis.speak(u);
+  }
   function show(){
     if (!pairs.length){ el("q").textContent="Žádná data"; return; }
     el("q").textContent = pairs[i].question;
@@ -43,6 +52,7 @@
     el("progress").textContent = `${i+1}/${pairs.length} • Správně: ${right}`;
     el("feedback").textContent = "";
   }
+  el("listen").addEventListener("click", ()=>speak(pairs[i].answer));
   el("answer").addEventListener("keydown", (e)=>{
     if (e.key==="Enter"){
       const guess = el("answer").value.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- Initialize all games via `GameSDK.init()` without the unused `activityKey` argument
- Drop unused `limit` metadata in missing-letters result reporting
- Document required `pack` parameter in game URLs so word data loads correctly
- Add a speaker button to the Write Word game that uses speech synthesis to pronounce each answer

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3098da000832ab58b08ac11ab63a5