### PR TITLE
Remove unused activityKey from game SDK initialization

### DIFF
--- a/games/flashcards/flashcards.html
+++ b/games/flashcards/flashcards.html
@@ -18,7 +18,7 @@
 <div class="container">
   <div class="card">
     <h1>Flashcards</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div id="panel" class="row">
   <div id="q" class="badge" style="font-size:28px"></div>
@@ -38,27 +38,27 @@
   </div>
 </div>
 <script>
-(async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
+window.addEventListener('DOMContentLoaded', async () => {
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i = 0, right = 0;
-  const el = (id)=>document.getElementById(id);
+  const el = (id) => document.getElementById(id);
   function show() {
     if (!pairs.length) { el("q").textContent = "Žádná data"; return; }
     const cur = pairs[i];
     el("q").textContent = cur.question;
     el("a").textContent = "";
   }
-  el("show").onclick = ()=> { el("a").textContent = pairs[i].answer; };
-  el("next").onclick = ()=> { i = (i+1) % pairs.length; show(); };
-  el("ok").onclick = ()=> { right++; i = (i+1) % pairs.length; show(); };
-  el("no").onclick = ()=> { i = (i+1) % pairs.length; show(); };
-  el("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
+  el("show").onclick = () => { el("a").textContent = pairs[i].answer; };
+  el("next").onclick = () => { i = (i + 1) % pairs.length; show(); };
+  el("ok").onclick = () => { right++; i = (i + 1) % pairs.length; show(); };
+  el("no").onclick = () => { i = (i + 1) % pairs.length; show(); };
+  el("finish").onclick = async () => {
+    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: { direction } });
     alert(`Uloženo: ${right}/${pairs.length}`);
     location.href = "/student.html";
   };
   show();
-})();
+});
 </script>
 </body>
 </html>

--- a/games/flashcards/index.html
+++ b/games/flashcards/index.html
@@ -28,7 +28,7 @@
 <div class="container">
   <div class="card">
     <h1>Flashcards</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div id="panel" class="row">
   <div id="q" class="badge" style="font-size:28px"></div>
@@ -48,27 +48,27 @@
   </div>
 </div>
 <script>
-(async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "flashcards" });
+window.addEventListener('DOMContentLoaded', async () => {
+  const { pairs, assignmentId, direction } = await GameSDK.init();
   let i = 0, right = 0;
-  const el = (id)=>document.getElementById(id);
+  const el = (id) => document.getElementById(id);
   function show() {
     if (!pairs.length) { el("q").textContent = "Žádná data"; return; }
     const cur = pairs[i];
     el("q").textContent = cur.question;
     el("a").textContent = "";
   }
-  el("show").onclick = ()=> { el("a").textContent = pairs[i].answer; };
-  el("next").onclick = ()=> { i = (i+1) % pairs.length; show(); };
-  el("ok").onclick = ()=> { right++; i = (i+1) % pairs.length; show(); };
-  el("no").onclick = ()=> { i = (i+1) % pairs.length; show(); };
-  el("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
+  el("show").onclick = () => { el("a").textContent = pairs[i].answer; };
+  el("next").onclick = () => { i = (i + 1) % pairs.length; show(); };
+  el("ok").onclick = () => { right++; i = (i + 1) % pairs.length; show(); };
+  el("no").onclick = () => { i = (i + 1) % pairs.length; show(); };
+  el("finish").onclick = async () => {
+    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: { direction } });
     alert(`Uloženo: ${right}/${pairs.length}`);
     location.href = "/student.html";
   };
   show();
-})();
+});
 </script>
 </body>
 </html>

--- a/games/missing-letters/index.html
+++ b/games/missing-letters/index.html
@@ -112,9 +112,9 @@ function buildLetterBank(answer, needCount){
 }
 
 /* ===== Hra ===== */
-(async () => {
+window.addEventListener('DOMContentLoaded', async () => {
   try {
-    const { pairs, assignmentId, direction, limit } = await GameSDK.init({ activityKey: "missing-letters" });
+    const { pairs, assignmentId, direction } = await GameSDK.init();
 
     let round = 0;
     let score = 0;
@@ -231,7 +231,7 @@ function buildLetterBank(answer, needCount){
         assignmentId,
         score,
         total: pairs.length,
-        extra: { direction, limit, activity: "missing-letters" }
+        extra: { direction, activity: "missing-letters" }
       });
       alert(`Uloženo: ${score}/${pairs.length}`);
       location.href = "/student.html";
@@ -240,11 +240,11 @@ function buildLetterBank(answer, needCount){
     // start
     newRound();
 
-  } catch (err){
+  } catch (err) {
     console.error("Chyba při initu hry:", err);
     alert(err?.message || "Nepodařilo se načíst data pro hru.");
   }
-})();
+});
 </script>
 </body>
 </html>

--- a/games/word-match/index.html
+++ b/games/word-match/index.html
@@ -27,7 +27,7 @@
 <div class="container">
   <div class="card">
     <h1>Word Match (spoj dvojice)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div class="row grid-2" id="cols"></div>
 <div class="small">Klikni nejprve na výraz vlevo, pak na překlad vpravo.</div>
@@ -37,58 +37,58 @@
   </div>
 </div>
 <script>
-(async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
-  const left = pairs.map(p=>({text:p.question, id: p.question}));
-  const right = pairs.map(p=>({text:p.answer, id: p.question}));
+window.addEventListener('DOMContentLoaded', async () => {
+  const { pairs, assignmentId, direction } = await GameSDK.init();
+  const left = pairs.map(p => ({ text: p.question, id: p.question }));
+  const right = pairs.map(p => ({ text: p.answer, id: p.question }));
   // shuffle
-  right.sort(()=>Math.random()-0.5);
+  right.sort(() => Math.random() - 0.5);
   const cols = document.getElementById("cols");
   cols.innerHTML = `<div class="col" id="L"></div><div class="col" id="R"></div>`;
   const L = document.getElementById("L");
   const R = document.getElementById("R");
   const prog = document.getElementById("progress");
-  let selectedLeft=null, selectedRight=null, solved=0;
-  function renderList(el, arr, side){
+  let selectedLeft = null, selectedRight = null, solved = 0;
+  function renderList(el, arr, side) {
     el.innerHTML = "";
-    arr.forEach(x=>{
+    arr.forEach(x => {
       const d = document.createElement("div");
       d.className = "item";
       d.textContent = x.text;
       d.dataset.id = x.id;
-      d.onclick = ()=>{
+      d.onclick = () => {
         if (d.classList.contains("done")) return;
-        el.querySelectorAll(".item").forEach(n=>n.classList.remove("active"));
+        el.querySelectorAll(".item").forEach(n => n.classList.remove("active"));
         d.classList.add("active");
-        if (side==="L"){ selectedLeft = x; }
+        if (side === "L") { selectedLeft = x; }
         else { selectedRight = x; }
         check();
       };
       el.appendChild(d);
     });
   }
-  function check(){
-    if (selectedLeft && selectedRight){
+  function check() {
+    if (selectedLeft && selectedRight) {
       const ok = selectedLeft.id === selectedRight.id;
       const mark = (el, id) => {
         const n = el.querySelector(`.item[data-id="${id}"]`);
-        if (n){ n.classList.remove("active"); if (ok){ n.classList.add("done"); n.style.pointerEvents="none"; } }
+        if (n) { n.classList.remove("active"); if (ok) { n.classList.add("done"); n.style.pointerEvents = "none"; } }
       };
       mark(L, selectedLeft.id); mark(R, selectedRight.id);
       if (ok) solved++;
-      selectedLeft=null; selectedRight=null;
+      selectedLeft = null; selectedRight = null;
       prog.textContent = `Správně: ${solved}/${pairs.length}`;
     }
   }
   renderList(L, left, "L");
   renderList(R, right, "R");
-  document.getElementById("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: solved, total: pairs.length, extra: {direction} });
+  document.getElementById("finish").onclick = async () => {
+    await GameSDK.reportResult({ assignmentId, score: solved, total: pairs.length, extra: { direction } });
     alert(`Uloženo: ${solved}/${pairs.length}`);
     location.href = "/student.html";
   };
   prog.textContent = `Správně: 0/${pairs.length}`;
-})();
+});
 </script>
 </body>
 </html>

--- a/games/word-match/word-match.html
+++ b/games/word-match/word-match.html
@@ -18,7 +18,7 @@
 <div class="container">
   <div class="card">
     <h1>Word Match (spoj dvojice)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div class="row grid-2" id="cols"></div>
 <div class="small">Klikni nejprve na výraz vlevo, pak na překlad vpravo.</div>
@@ -28,58 +28,58 @@
   </div>
 </div>
 <script>
-(async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "word-match" });
-  const left = pairs.map(p=>({text:p.question, id: p.question}));
-  const right = pairs.map(p=>({text:p.answer, id: p.question}));
+window.addEventListener('DOMContentLoaded', async () => {
+  const { pairs, assignmentId, direction } = await GameSDK.init();
+  const left = pairs.map(p => ({ text: p.question, id: p.question }));
+  const right = pairs.map(p => ({ text: p.answer, id: p.question }));
   // shuffle
-  right.sort(()=>Math.random()-0.5);
+  right.sort(() => Math.random() - 0.5);
   const cols = document.getElementById("cols");
   cols.innerHTML = `<div class="col" id="L"></div><div class="col" id="R"></div>`;
   const L = document.getElementById("L");
   const R = document.getElementById("R");
   const prog = document.getElementById("progress");
-  let selectedLeft=null, selectedRight=null, solved=0;
-  function renderList(el, arr, side){
+  let selectedLeft = null, selectedRight = null, solved = 0;
+  function renderList(el, arr, side) {
     el.innerHTML = "";
-    arr.forEach(x=>{
+    arr.forEach(x => {
       const d = document.createElement("div");
       d.className = "item";
       d.textContent = x.text;
       d.dataset.id = x.id;
-      d.onclick = ()=>{
+      d.onclick = () => {
         if (d.classList.contains("done")) return;
-        el.querySelectorAll(".item").forEach(n=>n.classList.remove("active"));
+        el.querySelectorAll(".item").forEach(n => n.classList.remove("active"));
         d.classList.add("active");
-        if (side==="L"){ selectedLeft = x; }
+        if (side === "L") { selectedLeft = x; }
         else { selectedRight = x; }
         check();
       };
       el.appendChild(d);
     });
   }
-  function check(){
-    if (selectedLeft && selectedRight){
+  function check() {
+    if (selectedLeft && selectedRight) {
       const ok = selectedLeft.id === selectedRight.id;
       const mark = (el, id) => {
         const n = el.querySelector(`.item[data-id="${id}"]`);
-        if (n){ n.classList.remove("active"); if (ok){ n.classList.add("done"); n.style.pointerEvents="none"; } }
+        if (n) { n.classList.remove("active"); if (ok) { n.classList.add("done"); n.style.pointerEvents = "none"; } }
       };
       mark(L, selectedLeft.id); mark(R, selectedRight.id);
       if (ok) solved++;
-      selectedLeft=null; selectedRight=null;
+      selectedLeft = null; selectedRight = null;
       prog.textContent = `Správně: ${solved}/${pairs.length}`;
     }
   }
   renderList(L, left, "L");
   renderList(R, right, "R");
-  document.getElementById("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: solved, total: pairs.length, extra: {direction} });
+  document.getElementById("finish").onclick = async () => {
+    await GameSDK.reportResult({ assignmentId, score: solved, total: pairs.length, extra: { direction } });
     alert(`Uloženo: ${solved}/${pairs.length}`);
     location.href = "/student.html";
   };
   prog.textContent = `Správně: 0/${pairs.length}`;
-})();
+});
 </script>
 </body>
 </html>

--- a/games/write-word/index.html
+++ b/games/write-word/index.html
@@ -27,11 +27,14 @@
 <div class="container">
   <div class="card">
     <h1>Write Word (napiš překlad)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div class="row">
   <div class="badge" id="q" style="font-size:24px"></div>
-  <input id="answer" placeholder="Napiš překlad a Enter" />
+  <div class="row grid-2">
+    <button id="listen" title="Přehrát výslovnost">🔊</button>
+    <input id="answer" placeholder="Napiš překlad a Enter" />
+  </div>
   <div id="feedback" class="small"></div>
   <div class="badge" id="progress"></div>
   <button id="finish">Ukončit a uložit</button>
@@ -40,38 +43,45 @@
   </div>
 </div>
 <script>
-(async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
-  let i=0, right=0;
-  const el = id=>document.getElementById(id);
-  function show(){
-    if (!pairs.length){ el("q").textContent="Žádná data"; return; }
+window.addEventListener('DOMContentLoaded', async () => {
+  const { pairs, assignmentId, direction } = await GameSDK.init();
+  let i = 0, right = 0;
+  const el = id => document.getElementById(id);
+  function speak(text) {
+    if (!('speechSynthesis' in window)) return;
+    const u = new SpeechSynthesisUtterance(text);
+    speechSynthesis.cancel();
+    speechSynthesis.speak(u);
+  }
+  function show() {
+    if (!pairs.length) { el("q").textContent = "Žádná data"; return; }
     el("q").textContent = pairs[i].question;
-    el("answer").value="";
+    el("answer").value = "";
     el("answer").focus();
-    el("progress").textContent = `${i+1}/${pairs.length} • Správně: ${right}`;
+    el("progress").textContent = `${i + 1}/${pairs.length} • Správně: ${right}`;
     el("feedback").textContent = "";
   }
-  el("answer").addEventListener("keydown", (e)=>{
-    if (e.key==="Enter"){
+  el("listen").addEventListener("click", () => speak(pairs[i].answer));
+  el("answer").addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
       const guess = el("answer").value.trim().toLowerCase();
       const ok = guess === pairs[i].answer.trim().toLowerCase();
-      if (ok){ right++; el("feedback").textContent = "✅ Správně"; }
+      if (ok) { right++; el("feedback").textContent = "✅ Správně"; }
       else { el("feedback").textContent = `❌ Správně: ${pairs[i].answer}`; }
-      i++; if (i>=pairs.length){ i=pairs.length-1; }
-      setTimeout(()=>{ if (i < pairs.length-0) { show(); } }, 400);
-      if (i>=pairs.length-0){
+      i++; if (i >= pairs.length) { i = pairs.length - 1; }
+      setTimeout(() => { if (i < pairs.length) { show(); } }, 400);
+      if (i >= pairs.length) {
         // hotovo
       }
     }
   });
-  document.getElementById("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
+  document.getElementById("finish").onclick = async () => {
+    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: { direction } });
     alert(`Uloženo: ${right}/${pairs.length}`);
     location.href = "/student.html";
   };
   show();
-})();
+});
 </script>
 </body>
 </html>

--- a/games/write-word/write-word.html
+++ b/games/write-word/write-word.html
@@ -18,11 +18,14 @@
 <div class="container">
   <div class="card">
     <h1>Write Word (napiš překlad)</h1>
-    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&dir=cz-en|en-cz&limit=20</code></p>
+    <p class="small">Parametry v URL: <code>?a=&lt;assignmentId&gt;&amp;pack=&lt;packId&gt;&amp;dir=cz-en|en-cz&amp;limit=20</code></p>
     
 <div class="row">
   <div class="badge" id="q" style="font-size:24px"></div>
-  <input id="answer" placeholder="Napiš překlad a Enter" />
+  <div class="row grid-2">
+    <button id="listen" title="Přehrát výslovnost">🔊</button>
+    <input id="answer" placeholder="Napiš překlad a Enter" />
+  </div>
   <div id="feedback" class="small"></div>
   <div class="badge" id="progress"></div>
   <button id="finish">Ukončit a uložit</button>
@@ -31,38 +34,45 @@
   </div>
 </div>
 <script>
-(async () => {
-  const { pairs, assignmentId, direction } = await GameSDK.init({ activityKey: "write-word" });
-  let i=0, right=0;
-  const el = id=>document.getElementById(id);
-  function show(){
-    if (!pairs.length){ el("q").textContent="Žádná data"; return; }
+window.addEventListener('DOMContentLoaded', async () => {
+  const { pairs, assignmentId, direction } = await GameSDK.init();
+  let i = 0, right = 0;
+  const el = id => document.getElementById(id);
+  function speak(text) {
+    if (!('speechSynthesis' in window)) return;
+    const u = new SpeechSynthesisUtterance(text);
+    speechSynthesis.cancel();
+    speechSynthesis.speak(u);
+  }
+  function show() {
+    if (!pairs.length) { el("q").textContent = "Žádná data"; return; }
     el("q").textContent = pairs[i].question;
-    el("answer").value="";
+    el("answer").value = "";
     el("answer").focus();
-    el("progress").textContent = `${i+1}/${pairs.length} • Správně: ${right}`;
+    el("progress").textContent = `${i + 1}/${pairs.length} • Správně: ${right}`;
     el("feedback").textContent = "";
   }
-  el("answer").addEventListener("keydown", (e)=>{
-    if (e.key==="Enter"){
+  el("listen").addEventListener("click", () => speak(pairs[i].answer));
+  el("answer").addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
       const guess = el("answer").value.trim().toLowerCase();
       const ok = guess === pairs[i].answer.trim().toLowerCase();
-      if (ok){ right++; el("feedback").textContent = "✅ Správně"; }
+      if (ok) { right++; el("feedback").textContent = "✅ Správně"; }
       else { el("feedback").textContent = `❌ Správně: ${pairs[i].answer}`; }
-      i++; if (i>=pairs.length){ i=pairs.length-1; }
-      setTimeout(()=>{ if (i < pairs.length-0) { show(); } }, 400);
-      if (i>=pairs.length-0){
+      i++; if (i >= pairs.length) { i = pairs.length - 1; }
+      setTimeout(() => { if (i < pairs.length) { show(); } }, 400);
+      if (i >= pairs.length) {
         // hotovo
       }
     }
   });
-  document.getElementById("finish").onclick = async ()=>{
-    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: {direction} });
+  document.getElementById("finish").onclick = async () => {
+    await GameSDK.reportResult({ assignmentId, score: right, total: pairs.length, extra: { direction } });
     alert(`Uloženo: ${right}/${pairs.length}`);
     location.href = "/student.html";
   };
   show();
-})();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Initialize all games via `GameSDK.init()` without the unused `activityKey` argument
- Drop unused `limit` metadata in missing-letters result reporting
- Document required `pack` parameter in game URLs so word data loads correctly
- Add a speaker button to the Write Word game that uses speech synthesis to pronounce each answer
- Delay each game’s startup until `DOMContentLoaded` so `GameSDK` is ready before loading word pairs

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3098da000832ab58b08ac11ab63a5